### PR TITLE
docs: fix broken links in Accessible Media Resources section

### DIFF
--- a/en_us/shared/accessibility/best_practices_course_content_dev.rst
+++ b/en_us/shared/accessibility/best_practices_course_content_dev.rst
@@ -928,9 +928,9 @@ learning materials for study and review.
 Accessible Media Resources
 =====================================================
 
-* `Accessible Digital Media Guidelines <http://ncam.wgbh.org/invent_build/web_multimedia/accessible-digital-media-guide>`_ provides detailed advice on creating online video and audio with accessibility in mind.
+* `Making Audio and Video Media Accessible <https://www.w3.org/WAI/media/av/>`_ from the W3C Web Accessibility Initiative provides detailed advice on creating online video and audio with accessibility in mind.
 * `Captioning Key <http://captioningkey.org/quality_captioning.html>`_ by the National Association for the Deaf provides excellent guidance on creating described and captioned media.
-* `Closed Captioning & Subtitling Standards in IP Video Programming <https://www.3playmedia.com/2016/06/16/closed-captioning-subtitling-standards-in-ip-video-programming/>`_ by 3PlayMedia discusses best practices in this recorded webinar and white paper.
+* `Closed Captioning & Subtitling Standards in IP Video Programming <https://www.3playmedia.com/blog/closed-captioning-subtitling-standards-in-ip-video-programming/>`_ by 3PlayMedia discusses best practices in this recorded webinar and white paper.
 
 .. _Best Practices for HTML Markup:
 


### PR DESCRIPTION
### Description

- Updates the “Accessible Media Resources” section to replace outdated/broken external references with current URLs, keeping the accessibility guidance usable for course content authors.

**Changes:**

- Replaced the obsolete NCAM “Accessible Digital Media Guidelines” link with a current W3C WAI media accessibility resource.
- Updated the 3PlayMedia “Closed Captioning & Subtitling Standards…” URL to its current path.

### Jira

- https://2u-internal.atlassian.net/browse/LP-709

**Before**

<img width="1031" height="307" alt="image" src="https://github.com/user-attachments/assets/b55bc0c1-a166-4934-9349-9ece8fc8557f" />

**After**

<img width="864" height="319" alt="image" src="https://github.com/user-attachments/assets/282b7850-ad02-49a9-83d4-5d1d2325c3b8" />

